### PR TITLE
[PAN-3651] Removed local_remote_access_ip_address from SSDVPS get server response

### DIFF
--- a/tests/Unit/ThgHosting/ThgHostingClientTest.php
+++ b/tests/Unit/ThgHosting/ThgHostingClientTest.php
@@ -286,7 +286,6 @@ final class ThgHostingClientTest extends TestCase
                         "operating_system_distro": "ubuntu",
                         "note": null,
                         "suspended": false,
-                        "local_remote_access_ip_address": "191.115.116.19",
                         "domain": "localdomain",
                         "ip_addresses": [
                           {


### PR DESCRIPTION
No need to release a new version, just tests affected